### PR TITLE
Adding configuration parameters to package

### DIFF
--- a/packages/fluxcd-source-controller/0.21.2/package.yaml
+++ b/packages/fluxcd-source-controller/0.21.2/package.yaml
@@ -6,9 +6,6 @@ spec:
   refName: fluxcd-source-controller.community.tanzu.vmware.com
   version: 0.21.2
   releasedAt: "2022-02-07T11:14:08Z"
-  valuesSchema:
-    openAPIv3:
-      properties: {}
   template:
     spec:
       fetch:
@@ -25,3 +22,26 @@ spec:
           - config/kapp.yml
       deploy:
       - kapp: {}
+  valuesSchema:
+    openAPIv3:
+      properties:
+        namespace:
+          type: string
+          description: Deployment and service namespace
+          default: source-system
+        limits_cpu:
+          type: string
+          description: Set cpu usuage limit
+          default: 1000m
+        limits_memory:
+          type: string
+          description: Set memory usuage limit
+          default: 1Gi
+        no_proxy:
+          type: string
+          description: Set domains for which no proxying should be performed
+          default: ""
+        https_proxy:
+          type: string
+          description: Set proxy connection information
+          default: ""

--- a/pipeline/pipeline.yml
+++ b/pipeline/pipeline.yml
@@ -210,7 +210,12 @@ jobs:
             cat > crds/config/values.yml <<EOL
             #@data/values
             ---
-            service_port: 80
+	    namespace: flux-system
+	    limits_cpu: 1000m
+            limits_memory: 1Gi
+	    service_port: 80
+	    no_proxy: ""
+	    https_proxy: ""            
             EOL
 
             # Adding kapp.yml to avoid Phanton diffs
@@ -312,8 +317,28 @@ jobs:
               version: #@ data.values.version
               releasedAt: #@ data.values.timestamp
               valuesSchema:
-                openAPIv3:
-                  properties: {}
+              openAPIv3:
+                properties:
+                  namespace:
+                    type: string
+                    description: Deployment and service namespace
+                    default: source-system
+                  limits_cpu:
+                    type: string
+                    description: Set cpu usuage limit
+                    default: 1000m
+                  limits_memory:
+                    type: string
+                    description: Set memory usuage limit
+                    default: 1Gi
+                  no_proxy:
+                    type: string
+                    description: Set domains for which no proxying should be performed
+                    default: ""
+                  https_proxy:
+                    type: string
+                    description: Set proxy connection information
+                    default: ""
               template:
                 spec:
                   fetch:


### PR DESCRIPTION
Adding configuration parameters to the source-controller package. 
Adding following parameters in package configuration:-

```
namespace: flux-system
limits_cpu: 1000m
limits_memory: 1Gi
service_port: 80
no_proxy: "" 
https_proxy: ""
```

For GitRepository proxy support we need to set the HTTPS_PROXY and NO_PROXY in the source controller pod.
If https_proxy or no_proxy values are passed as empty then we are not adding that variable in the env variable list of source controller pod. 
